### PR TITLE
Fix variable message types which get rejected by ElasticSearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "log4js-logstash",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "author": "Gembly Games B.V.",
     "description": "A simple log appender for log4js thats sends the data to logstash",
     "keywords": [

--- a/tests/test.js
+++ b/tests/test.js
@@ -49,5 +49,25 @@ module.exports = {
             });
         });
         log({ level: {levelStr: 'FOO'}, categoryName: 'BAR', data: [message] });
+    },
+    'When log message is an object, it gets converted to a string': function (test) {
+        "use strict";
+        var self = this,
+            message = { error: true, errorMessage: "something happened"},
+            log;
+
+        test.doesNotThrow(function () {
+            log = log4jsAppender.configure(self.config);
+        }, 'Error', 'Configure shouldn\'t throw an error');
+
+        this.testServer.on('connection', function (con) {
+            con.on('data', function (data) {
+                test.strictEqual(JSON.parse(data.toString())['@message'],
+                    '{"error":true,"errorMessage":"something happened"}', 
+                    'data should be message!');
+                test.done();
+            });
+        });
+        log({ level: {levelStr: 'FOO'}, categoryName: 'BAR', data: [message] });
     }
 };


### PR DESCRIPTION
ElasticSearch will reject messages that have changed type, for example

The log could look like this:

    {
        message: "message",
        error: false
    }
and like this

    {
        message: { errorLog: true, errorMessage: "some message"},
        error: true
    }

The message field can't be both a string type (first example) and an object (second example). Whichever format is seen first sets the field type, and all documents with the other format are rejected.

This fix will make sure that message will always be string. 